### PR TITLE
Chore: Remove `main`

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -1,6 +1,0 @@
-main () {
-  source ${0%/*}/sorting-algorithms/counting-sort.sh
-  main
-}
-
-main


### PR DESCRIPTION
- This repo has uncoupled script files. They don't need a `main` that
  runs everything.
